### PR TITLE
New dockerfile for rabbitmq 3.8.16

### DIFF
--- a/Dockerfile.3.8.16
+++ b/Dockerfile.3.8.16
@@ -1,0 +1,15 @@
+FROM rabbitmq:3.8.16-management
+
+RUN apt-get update && \
+apt-get install -y curl unzip
+
+RUN curl -L https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.8.9/rabbitmq_delayed_message_exchange-3.8.9-0199d11c.ez > rabbitmq_delayed_message_exchange.ez && \
+mv rabbitmq_delayed_message_exchange.ez plugins/
+
+
+RUN rabbitmq-plugins enable --offline rabbitmq_management  &&\
+    rabbitmq-plugins enable --offline rabbitmq_shovel rabbitmq_shovel_management &&\
+    rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
+
+# Management plugin ports
+EXPOSE 15671 15672


### PR DESCRIPTION
This is a Dockerfile with an upgraded version of RabbitMQ that devs can use in their local environments.

RabbitMQ: 3.8.16
Erlang: 23.3.4
RabbitMQ Delayed Message plugin: 3.8.9

**Deployment**
Currently the rabbitMQ image for running `sunco` is downloaded from this git repository. A dev that wants to use the updated image can do so by updating [this line](https://github.com/zendesk/sunco/blob/master/docker/docker-compose-dev.yml#L34) to `Dockerfile.3.8.16`. 

A posting will be done in `sunco-eng` about devs updating their docker-compose file to this image in order to iron out any problems that the new update might cause. `COMPOSE_DOCKER_CLI_BUILD=0 docker-compose -p Smooch -f docker/docker-compose-dev.yml up --build` would need to be run the first time to retrieve the updated rabbitMQ image (this is the `npm run containers` command with the addition of the `--build` flag)

**Manual Tests**
- Send a slack message
- Send a API Post user message
- Receive/Respond from whatsapp